### PR TITLE
Fix typing for python < 3.10

### DIFF
--- a/src/tryptag/tryptag.py
+++ b/src/tryptag/tryptag.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from functools import cached_property
 import urllib.request
 import os


### PR DESCRIPTION
Fixes an import error on python versions smaller than 3.10 due to the new type specification syntax being used. This is fixed by simply importing `__futures__.annotations`.