### PR TITLE
Implement BioimageArchive data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ If you use the TrypTag data resource, please cite Billington _et al._ 2023 Natur
 We recommend including this citation in the results or methods if TrypTag was used as part of a discovery process.
 If directly using TrypTag images, please also indicate in the figure legend or similar which images are from TrypTag.
 
-If you use the `tryptag` module to access or analyse TrypTag data, please also cite this [Github repository](https://github.com/zephyris/tryptag) and the master TrypTag Zenodo deposition [doi:10.5281/zenodo.6862289](https://doi.org/10.5281/zenodo.6862289).
+If you use the `tryptag` module to access or analyse TrypTag data, please also cite this [Github repository](https://github.com/zephyris/tryptag) and the TrypTag deposition on the BioImage Archive [doi:10.6019/S-BIAD1866](https://doi.org/10.6019/S-BIAD1866).
 
 You may also find the following papers of use:
 1. Dean _et al._ 2019 Trends Parasitol. [doi:10.1016/j.pt.2016.10.009](https://doi.org/10.1016/j.pt.2016.10.009) Project announcement, with original aims and experimental strategy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ deps = [
 	"pytest>=8",
 	"pytest-sugar",
 ]
+pass_env = [
+	"BIA_SECRET_KEY",
+]
 commands = [[ "pytest", "tests", { replace = "posargs", extend = true} ]]
 
 [tool.tox.env.type]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,6 @@ deps = [
 	"pytest>=8",
 	"pytest-sugar",
 ]
-pass_env = [
-	"BIA_SECRET_KEY",
-]
 commands = [[ "pytest", "tests", { replace = "posargs", extend = true} ]]
 
 [tool.tox.env.type]

--- a/src/tryptag/bia.py
+++ b/src/tryptag/bia.py
@@ -3,7 +3,6 @@ import fnmatch
 import io
 import json
 import logging
-import os
 import pathlib
 from typing import Literal
 
@@ -17,16 +16,8 @@ from tryptag.tryptag import TrypTag
 
 logger = logging.getLogger("tryptag.bia")
 
-# TODO: Remove private key!
-if "BIA_SECRET_KEY" in os.environ:
-    BIA_API_ROOT = (
-        "https://ftp.ebi.ac.uk/pub/databases/biostudies/.private/"
-        f"{os.environ['BIA_SECRET_KEY']}/S-BIAD"
-    )
-else:
-    BIA_API_ROOT = "https://ftp.ebi.ac.uk/pub/databases/biostudies/S-BIAD"
+BIA_API_ROOT = "https://ftp.ebi.ac.uk/pub/databases/biostudies/S-BIAD"
 DOWNLOAD_MAX_TRIES = 3
-
 
 FILE_TYPES = {
     "Cell ROIs": FileTypes.CELL_ROIS,

--- a/src/tryptag/bia.py
+++ b/src/tryptag/bia.py
@@ -9,10 +9,8 @@ from typing import Literal
 import requests
 from tqdm import tqdm
 
-from tryptag import tryptools
 from tryptag.cache import Cache, FileTypes
 from tryptag.datasource import DataSource
-from tryptag.tryptag import TrypTag
 
 logger = logging.getLogger("tryptag.bia")
 
@@ -181,35 +179,3 @@ class BioimageArchive(DataSource):
         return [
             str(pathlib.Path(p).relative_to(plate)) for p in matches
         ]
-
-
-if __name__ == "__main__":
-    cache = Cache('_bia_cache')
-    bia = BioimageArchive(cache)
-    tt = TrypTag(datasource=bia)
-
-    def analyse(tryptag, cell_line):
-        result = {}
-        fieldcell_list = tryptag.cell_list(cell_line)
-        for fieldcell in fieldcell_list:
-            cell_image = tryptag.open_cell(
-                cell_line, fieldcell.field.index, fieldcell.index)
-            kn_result = tryptools.cell_kn_analysis(cell_image)
-            if kn_result["count_kn"] not in result:
-                result[kn_result["count_kn"]] = 0
-            result[kn_result["count_kn"]] += 1
-        return result
-
-    worklist = tt.worklist_parental()
-    # Sort results, otherwise the comparison fails.
-    results = sorted(
-        tt.analyse_list(
-            worklist,
-            analyse,
-            multiprocess_mode="thread",
-            workers=None,
-        ),
-        key=lambda e: (e["cell_line"].gene_id, e["cell_line"].terminus)
-    )
-
-    print(results)

--- a/src/tryptag/bia.py
+++ b/src/tryptag/bia.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+import fnmatch
+import io
+import json
+import logging
+import os
+import pathlib
+from typing import Literal
+
+import requests
+from tqdm import tqdm
+
+from tryptag import tryptools
+from tryptag.cache import Cache, FileTypes
+from tryptag.datasource import DataSource
+from tryptag.tryptag import TrypTag
+
+logger = logging.getLogger("tryptag.bia")
+
+# TODO: Remove private key!
+if "BIA_SECRET_KEY" in os.environ:
+    BIA_API_ROOT = (
+        "https://ftp.ebi.ac.uk/pub/databases/biostudies/.private/"
+        f"{os.environ['BIA_SECRET_KEY']}/S-BIAD"
+    )
+else:
+    BIA_API_ROOT = "https://ftp.ebi.ac.uk/pub/databases/biostudies/S-BIAD"
+DOWNLOAD_MAX_TRIES = 3
+
+
+FILE_TYPES = {
+    "Cell ROIs": FileTypes.CELL_ROIS,
+    "Corrected image": FileTypes.IMAGE,
+    "Thresholded image": FileTypes.THRESHOLDED,
+    "Localisation annotation": FileTypes.LOCALISATION,
+    "Other": FileTypes.OTHER,
+}
+
+
+class BiaFile:
+    path: str
+    size: int
+    file_type: FileTypes = FileTypes.OTHER
+    plate: str | None = None
+    gene_id: str | None = None
+    terminus: Literal["C", "N"] | None = None
+    field_index: int | None = None
+
+    def __init__(self, data: dict, bia: BioimageArchive):
+        self.path = data["path"]
+        self.url = bia._file_url(self.path)
+        self.size = data["size"]
+        if "attributes" in data:
+            attributes = {
+                e["name"]: e["value"] for e in data["attributes"]
+                if "value" in e
+            }
+            if "FileType" in attributes:
+                self.file_type = FILE_TYPES[attributes["FileType"]]
+            if "Plate" in attributes:
+                self.plate = f"{attributes['Plate']}_{attributes['Date']}"
+            if "Gene ID" in attributes:
+                self.gene_id = attributes["Gene ID"]
+            if "Terminus" in attributes:
+                self.terminus = attributes["Terminus"]
+            if "Field" in attributes:
+                self.field_index = int(attributes["Field"])
+
+    def download(
+        self,
+        outfile: io.BufferedIOBase
+    ):
+        """
+        Download the file from BIA and write to the given file object.
+
+        :param outfile: file-like, file object the downloaded file should be
+            written to.
+        """
+
+        logger.debug(f"Downloading {self.path} from URL {self.url}.")
+        r = requests.get(
+            self.url,
+            stream=True,
+            headers={
+                "Accept-Encoding": "gzip",
+            }
+        )
+        r.raise_for_status()
+        total_size = int(r.headers.get("content-length", 0))
+        block_size = 1024
+
+        def log_progress(chunks):
+            if total_size == 0:
+                for chunk in chunks:
+                    yield chunk
+            else:
+                progress = 0
+                delta = 0
+                for chunk in chunks:
+                    delta += block_size
+                    progress += block_size
+                    delta_percentage = 100 * (delta / total_size)
+                    if delta_percentage >= 10:
+                        logger.debug(
+                            f"{self.path}: {progress} / {total_size}")
+                        delta = 0
+                    yield chunk
+                logger.debug(f"{self.path}: {total_size} / {total_size}")
+
+        # TODO: check downloaded file size!
+
+        with tqdm(
+            desc=f"Downloading {self.path}",
+            total=total_size,
+            unit="B",
+            unit_scale=True,
+            disable=logger.getEffectiveLevel() != logging.INFO,
+        ) as progress_bar:
+            for chunk in log_progress(r.iter_content(block_size)):
+                progress_bar.update(len(chunk))
+                outfile.write(chunk)
+
+
+class BioimageArchive(DataSource):
+    """Class to read TrypTag data from Bioimage Archive
+
+    This subclasses the `DataSource` abstract base class and implements the
+    methods to access data via the EMBL Bioimage Archive.
+    """
+    def __init__(
+        self,
+        cache: Cache,
+        accession: str = "S-BIAD1866",
+    ):
+        super().__init__(cache)
+        self.accession = accession
+        self._get_file_index()
+        self.__post_init__()
+
+    @property
+    def _url_root(self):
+        return (
+            f"{BIA_API_ROOT}/{self.accession.replace('S-BIAD1', '')}"
+            f"/{self.accession}/Files/"
+        )
+
+    def _file_url(self, path: str):
+        return f"{self._url_root}/{path}"
+
+    def fetch_root_file(self, filename: str):
+        logger.debug(f"Fetching root file {filename}.")
+        biafile = self._file_index[filename]
+        with open(self.cache.file_path(biafile.path), "wb") as outfile:
+            biafile.download(outfile)
+
+    def fetch_plate_file(self, plate, filename):
+        self.fetch_root_file(f"{plate}/{filename}")
+
+    def _get_file_index(self):
+        logger.debug("Loading file index.")
+
+        # Slightly hackish, but gets the job done without duplicating
+        # download code.
+        self._file_index: dict[str, BiaFile] = {
+            "Files.json": BiaFile({"path": "Files.json", "size": -1}, self)
+        }
+        with self.load_root_file("Files.json") as filesfile:
+            data: list[dict] = json.load(filesfile)
+
+        self._file_index = {}
+        for entry in data:
+            biafile = BiaFile(entry, self)
+            if biafile.path in self._file_index:
+                raise ValueError(f"Duplicate file in index {biafile.path}")
+            self._file_index[biafile.path] = biafile
+
+    def glob_plate_files(self, plate: str, pattern: str):
+        """
+        Find and return a list of files matching the given pattern in the
+        given plate.
+
+        :param plate: str, the name of the plate the files are located in
+        :param pattern: str, a shell-like glob pattern
+        :return: a list of file matching the pattern
+        """
+        matches = fnmatch.filter(
+            self._file_index,
+            f"{plate}/{pattern}",
+        )
+        return [
+            str(pathlib.Path(p).relative_to(plate)) for p in matches
+        ]
+
+
+if __name__ == "__main__":
+    cache = Cache('_bia_cache')
+    bia = BioimageArchive(cache)
+    tt = TrypTag(datasource=bia)
+
+    def analyse(tryptag, cell_line):
+        result = {}
+        fieldcell_list = tryptag.cell_list(cell_line)
+        for fieldcell in fieldcell_list:
+            cell_image = tryptag.open_cell(
+                cell_line, fieldcell.field.index, fieldcell.index)
+            kn_result = tryptools.cell_kn_analysis(cell_image)
+            if kn_result["count_kn"] not in result:
+                result[kn_result["count_kn"]] = 0
+            result[kn_result["count_kn"]] += 1
+        return result
+
+    worklist = tt.worklist_parental()
+    # Sort results, otherwise the comparison fails.
+    results = sorted(
+        tt.analyse_list(
+            worklist,
+            analyse,
+            multiprocess_mode="thread",
+            workers=None,
+        ),
+        key=lambda e: (e["cell_line"].gene_id, e["cell_line"].terminus)
+    )
+
+    print(results)

--- a/src/tryptag/cache.py
+++ b/src/tryptag/cache.py
@@ -21,6 +21,8 @@ class FileTypes(StrEnum):
     CELL_ROIS = "_roisCells.txt"
     THRESHOLDED = "_thr.tif"
     IMAGE = ".tif"
+    LOCALISATION = ".json"
+    OTHER = ""
 
 
 FILE_PATTERN = FileTypes.CELL_ROIS
@@ -152,6 +154,7 @@ class Cache:
         :param plate: str, name of the plate
         :param zipfilepath: Path, path to the zip file to be extracted.
         """
+        # TODO: We should move this to the Zenodo class.
         logger.debug(f"Extracting zip file {zipfilepath} for plate {plate}.")
         with zipfile.ZipFile(zipfilepath) as zip:
             fields = [
@@ -172,7 +175,11 @@ class Cache:
                 desc=f"Extracting {plate}",
                 disable=logger.getEffectiveLevel() != logging.INFO,
             ):
-                for filetype in FileTypes:
+                for filetype in [
+                    FileTypes.CELL_ROIS,
+                    FileTypes.IMAGE,
+                    FileTypes.THRESHOLDED,
+                ]:
                     zippath = pathlib.Path(str(field) + filetype)
                     zipinfo = zip.getinfo(str(zippath))
 

--- a/src/tryptag/datasource.py
+++ b/src/tryptag/datasource.py
@@ -309,7 +309,7 @@ class CellLine:
     def __hash__(self):
         return hash(
             (self.datasource, self.gene.id, self.terminus, self.life_stage))
-    
+
     def __eq__(self, other: CellLine):
         return (
             self.gene_id == other.gene_id and

--- a/src/tryptag/datasource.py
+++ b/src/tryptag/datasource.py
@@ -432,6 +432,7 @@ class DataSource:
         :param cache: the file system cache object we'll be using
         """
         self.cache = cache
+        self.cache.verify_cache_datasource(self)
 
     def __post_init__(self):
         """Post init function of the `DataSource` base class.

--- a/src/tryptag/tryptag.py
+++ b/src/tryptag/tryptag.py
@@ -3,17 +3,17 @@ import logging
 from typing import Callable, Literal
 import warnings
 
-from tryptag.processing import WorkList
-
+from .bia import BioimageArchive
 from .cache import Cache
 from .datasource import CellLine, CellLineStatus, DataSource
+from .processing import WorkList
 from .zenodo import Zenodo
 from .images import FieldImage, CellImage
 
 logger = logging.getLogger("tryptag")
 
 STANDARD_DATASOURCES = {
-    "procyclic": lambda cache: Zenodo(cache, master_record_id=6862289),
+    "procyclic": lambda cache: BioimageArchive(cache, accession="S-BIAD1866"),
     "bloodstream": lambda cache: Zenodo(cache, master_record_id=7258722)
 }
 

--- a/src/tryptag/tryptag.py
+++ b/src/tryptag/tryptag.py
@@ -28,7 +28,7 @@ class TrypTag:
         verbose: bool = False,
         data_cache_path: str = "./_tryptag_cache",
         um_per_px: float = 6.5 / 63,
-        dataset_name: str | None = "procyclic",
+        dataset_name: str | None = None,
         datasource: DataSource | None = None,
         life_stages: list[str] | None = None,  # deprecated
     ):
@@ -50,6 +50,13 @@ class TrypTag:
 
         if verbose:
             logger.setLevel(logging.DEBUG)
+
+        if (
+            dataset_name is None and
+            datasource is None and
+            life_stages is None
+        ):
+            dataset_name = "procyclic"
 
         if life_stages is not None:
             warnings.warn(
@@ -79,7 +86,7 @@ class TrypTag:
             dataset_name = life_stages[0]
         if dataset_name is not None and datasource is not None:
             raise ValueError(
-                "life_stage and data_source cannot be specified at the same "
+                "dataset_name and data_source cannot be specified at the same "
                 "time."
             )
         elif dataset_name is not None:

--- a/tests/test_tryptag.py
+++ b/tests/test_tryptag.py
@@ -1,12 +1,31 @@
 from tryptag import TrypTag, tryptools
 from tryptag.bia import BioimageArchive
-from tryptag.cache import Cache
+from tryptag.cache import Cache, IncompatibleCacheError
 from tryptag.images import CellImage
 from tryptag.datasource import CellLine
 from tryptag.zenodo import Zenodo
 
 import pytest
 
+
+def test_data_origin_check(tmp_path):
+    cache = Cache(tmp_path)
+    BioimageArchive(cache)
+
+    cache = Cache(tmp_path)
+    with pytest.raises(IncompatibleCacheError):
+        Zenodo(cache)
+
+    cache.delete()
+
+    cache = Cache(tmp_path)
+    Zenodo(cache)
+
+    cache = Cache(tmp_path)
+    with pytest.raises(IncompatibleCacheError):
+        BioimageArchive(cache)
+
+    cache.delete()
 
 @pytest.fixture(
     scope="session",

--- a/tests/test_tryptag.py
+++ b/tests/test_tryptag.py
@@ -8,6 +8,10 @@ from tryptag.zenodo import Zenodo
 import pytest
 
 
+def test_default(tmp_path):
+    TrypTag(data_cache_path=tmp_path)
+
+
 def test_data_origin_check(tmp_path):
     cache = Cache(tmp_path)
     BioimageArchive(cache)
@@ -29,7 +33,7 @@ def test_data_origin_check(tmp_path):
 
 @pytest.fixture(
     scope="session",
-    params=["zenodo", "bia"],
+    params=["bia", "zenodo"],
 )
 def tt_instance(tmp_path_factory, request):
     datasource_name = request.param


### PR DESCRIPTION
This PR implements the Bioimage Archive DataSource, that allows access to TrypTag data from the EMBL BioStudies Bioimage Archive repository.

This has the advantage of allowing random access to single files and generally faster download speeds.