### PR TITLE
Update examples & implement rich display options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tryptag = TrypTag()
 ```
 
 Microscopy data is multiple fields of view per cell line.
-It can be accessed using instances of `CellLine`, a simple class defining cell line life cycle stage, gene id (as used on [TriTrypDB](http://tritrypdb.org)), tagging terminus (`n` or `c`). There are multiple fields of view, accessed by field_index:
+It can be accessed using instances of `CellLine`, a simple class defining the gene id (as used on [TriTrypDB](http://tritrypdb.org)) and tagging terminus (`n` or `c`). There are multiple fields of view, accessed by field_index:
 
 ```python
 from tryptag import CellLine
@@ -77,11 +77,13 @@ io.show()
 Bear in mind that accessing a nonexistant gene id, tagging terminus, field or cell will give `KeyError` errors. For example:
 
 ```python
+from tryptag import FieldNotFoundError
+
 for field_index in range(7):
     try:
         field_image = tryptag.open_field(cell_line, field_index)
         # do your analysis here
-    except:
+    except FieldNotFoundError:
         print("Field not found, field_index:", field_index)
 ```
 
@@ -138,12 +140,6 @@ The `tryptools` methods take a `CellImage` object as an input and return various
 cell_image = tryptag.open_cell(CellLine(gene_id="Tb927.9.8570", terminus="n"))
 morphology_result = tryptools.cell_morphology_analysis(cell_image)
 ```
-
-It is possible to explicitly request cell lines from a specific life stage by using:
-```python
-cell_line = CellLine(life_stage="procyclic", gene_id="Tb927.9.8570", terminus="n")
-```
-If the `life_stage` argument is not given, it uses the first life stage given when the `TrypTag` object was initialised ("procyclic" by default).
 
 ### High throughput
 
@@ -211,7 +207,7 @@ or Windows:
 tryptag = TrypTag(data_cache_path = "Z:/my/scratch/directory")
 ```
 
-Do not delete or move files from `data_cache_path`. `tryptag` does not check the plate subdirectories for integrity. You can, however, safely delete a plate subdirectory.
+Do not delete or move files from `data_cache_path`.
 Interrupt of either data download or zip decompression _should_ behave gracefully, leaving partial data but not preventing later automatic re-download and/or re-decompression.
 
 If multiple scripts using the same `data_cache_path` simultaneously try to download a plate it _should_ be handled gracefully.
@@ -238,10 +234,10 @@ This gets populated with information about number of fields of view, cell locati
 ```python
 from tryptag import TrypTag, CellLine
 tryptag = TrypTag()
-life_stage, gene_id, terminus = "procyclic", "Tb927.9.8570", "n"
-localisation = tryptag.gene_list[life_stage][gene_id][terminus]["loc"]
-tryptag.cell_list(CellLine(life_stage=life_stage, gene_id=gene_id, terminus=terminus))
-cell_information = tryptag.gene_list[life_stage][gene_id][terminus]["cells"]
+gene_id, terminus = "Tb927.9.8570", "n"
+localisation = tryptag.gene_list[gene_id][terminus]["loc"]
+tryptag.cell_list(CellLine(gene_id=gene_id, terminus=terminus))
+cell_information = tryptag.gene_list[gene_id][terminus]["cells"]
 ```
 
 # Citing

--- a/README.md
+++ b/README.md
@@ -222,13 +222,8 @@ However, for large-scale analyses, it is more robust to ensure all data is alrea
 tryptag.fetch_all_data()
 ```
 
-The TrypTag data may have minor errors which will be corrected over time. `fetch_all_data` always fetches the latest localisation listing from [Zenodo](https://zenodo.org/record/6862289).
-Cached image data may be an older version. `tryptag` records the MD5 hash of the source zip files. If the data source (Zenodo depositions) are updated, the MD5 hash will change.
-Cached data inconsistent MD5 hashes can be checked and reported (but currently not corrected) using:
-
-```python
-tryptag.check_data_cache_integrity()
-```
+The TrypTag data may have minor errors which will be corrected over time. `fetch_all_data` always fetches the latest localisation listing from the data source.
+Cached image data may be an older version.
 
 `tryptag` gives quite verbose information about what it is currently doing to fetch data. To silence this output:
 

--- a/examples/analyse_list.ipynb
+++ b/examples/analyse_list.ipynb
@@ -1,28 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "private_outputs": true,
-      "provenance": [],
-      "authorship_tag": "ABX9TyP873zpmLa7ZFN+ho6AH70X",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "gpuClass": "standard"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/zephyris/tryptag/blob/main/examples/analyse_list.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -45,6 +27,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "aEci6ZNT1nF6"
+      },
+      "outputs": [],
       "source": [
         "#@title Setup tryptag\n",
         "\n",
@@ -58,38 +45,30 @@
         "\n",
         "# define a function to print worklists nicely\n",
         "def prettyprint_worklist(worklist, max_shown=15):\n",
-        "  print(len(worklist), \"worklist entries\")\n",
-        "  for i in range(min(len(worklist), max_shown)):\n",
-        "    print(worklist[i].gene_id, worklist[i].terminus, \":\", loc_to_str(tryptag.gene_list[tryptag.life_stages[0]][worklist[i].gene_id][worklist[i].terminus][\"loc\"]))\n",
-        "  if len(worklist) > max_shown:\n",
-        "    print(\" ... and\", len(worklist) - max_shown, \"more\")\n",
+        "    print(len(worklist), \"worklist entries\")\n",
+        "    for entry in worklist[:max_shown]:\n",
+        "        print(f\"{entry.gene_id} {entry.terminus}: {entry.localisation}\")\n",
+        "        #print(worklist[i].gene_id, worklist[i].terminus, \":\", loc_to_str(tryptag.gene_list[tryptag.life_stages[0]][worklist[i].gene_id][worklist[i].terminus][\"loc\"]))\n",
+        "    if len(worklist) > max_shown:\n",
+        "        print(\" ... and\", len(worklist) - max_shown, \"more\")\n",
         "\n",
         "# define a function to print results nicely\n",
         "def prettyprint_results(results, max_shown=15):\n",
-        "  print(len(results), \"results\")\n",
-        "  for i in range(min(len(results), max_shown)):\n",
-        "    print(results[i][\"cell_line\"].gene_id, results[i][\"cell_line\"].terminus, \":\", results[i][\"result\"])\n",
-        "  if len(results) > max_shown:\n",
-        "    print(\" ... and\", len(results) - max_shown, \"more\")\n",
-        "\n",
-        "# define a function to print localisation objects as nice strings\n",
-        "def loc_to_str(locs):\n",
-        "  loc_strs = []\n",
-        "  for loc in locs:\n",
-        "    str = loc[\"term\"]\n",
-        "    if \"modifiers\" in loc:\n",
-        "      str = str + \"[\"+\", \".join(loc[\"modifiers\"])+\"]\"\n",
-        "    loc_strs.append(str)\n",
-        "  return \", \".join(loc_strs)"
-      ],
-      "metadata": {
-        "id": "aEci6ZNT1nF6"
-      },
-      "execution_count": null,
-      "outputs": []
+        "    print(len(results), \"results\")\n",
+        "    for entry in results[:max_shown]:\n",
+        "        cell_line = entry[\"cell_line\"]\n",
+        "        print(f\"{cell_line.gene_id} {cell_line.terminus}:\", entry[\"result\"])\n",
+        "    if len(results) > max_shown:\n",
+        "        print(\" ... and\", len(results) - max_shown, \"more\")"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "O6-kr8NA4iTK"
+      },
+      "outputs": [],
       "source": [
         "#@title Set up a worklist\n",
         "\n",
@@ -104,26 +83,26 @@
         "#@markdown If you're trying out this notebook, you probably want to use the `worklist_parental` worklist to avoid downloading too much data.\n",
         "\n",
         "if worklist_type == \"worklist_parental\":\n",
-        "  print(\"Using parental worklist\")\n",
-        "  worklist = tryptag.worklist_parental()\n",
+        "    print(\"Using parental worklist\")\n",
+        "    worklist = tryptag.worklist_parental()\n",
         "elif worklist_type == \"worklist_all\":\n",
-        "  print(\"Using all worklist\")\n",
-        "  worklist = tryptag.worklist_all()\n",
+        "    print(\"Using all worklist\")\n",
+        "    worklist = tryptag.worklist_all()\n",
         "elif worklist_type == \"localisation_search\":\n",
-        "  print(\"Using example localisation search worklist\")\n",
-        "  print(\"Searching for `lipid droplets`\")\n",
-        "  worklist = tryptag.localisation_search(\"lipid droplet\")\n",
+        "    print(\"Using example localisation search worklist\")\n",
+        "    print(\"Searching for `lipid droplets`\")\n",
+        "    worklist = tryptag.localisation_search(\"lipid droplet\")\n",
         "\n",
         "prettyprint_worklist(worklist)"
-      ],
-      "metadata": {
-        "id": "O6-kr8NA4iTK"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "fJSlnEoGZ-qN"
+      },
+      "outputs": [],
       "source": [
         "#@title A simple multithreaded analysis\n",
         "\n",
@@ -137,15 +116,15 @@
         "# tryptag is an instance of TrypTag, passed from the parallel processing code\n",
         "# gene_id and terminus are passed from your worklist, the parallel processing code has already fetched the data for that gene_id/terminus\n",
         "def analyse(tryptag, cell_line):\n",
-        "  result = {}\n",
-        "  fieldcell_list = tryptag.cell_list(cell_line)\n",
-        "  for fieldcell in fieldcell_list:\n",
-        "    cell_image = tryptag.open_cell(cell_line, fieldcell[\"field_index\"], fieldcell[\"cell_index\"])\n",
-        "    kn_result = tryptools.cell_kn_analysis(cell_image)\n",
-        "    if kn_result[\"count_kn\"] not in result:\n",
-        "      result[kn_result[\"count_kn\"]] = 0\n",
-        "    result[kn_result[\"count_kn\"]] += 1\n",
-        "  return result\n",
+        "    result = {}\n",
+        "    cell_list = tryptag.cell_list(cell_line)\n",
+        "    for cell in cell_list:\n",
+        "        cell_image = tryptag.open_cell(cell_line, cell.field.index, cell.index)\n",
+        "        kn_result = tryptools.cell_kn_analysis(cell_image)\n",
+        "        if kn_result[\"count_kn\"] not in result:\n",
+        "            result[kn_result[\"count_kn\"]] = 0\n",
+        "        result[kn_result[\"count_kn\"]] += 1\n",
+        "    return result\n",
         "\n",
         "# do the analysis\n",
         "results = tryptag.analyse_list(worklist, analyse)\n",
@@ -155,15 +134,15 @@
         "\n",
         "# print the results\n",
         "prettyprint_results(results)\n"
-      ],
-      "metadata": {
-        "id": "fJSlnEoGZ-qN"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6KRDNvV97kUq"
+      },
+      "outputs": [],
       "source": [
         "#@title Controlling multiprocessing parameters\n",
         "\n",
@@ -174,24 +153,47 @@
         "#@markdown Default behaviour (if you do not set `multiprocess_mode`) is to use `process`, which is probably the best solution unless you really know what you're doing.\n",
         "#@markdown Selecting `None` can help simplify error messages for debugging.\n",
         "\n",
-        "multiprocess_mode = \"process\" #@param [\"None\", \"process\", \"thread\"]\n",
+        "multiprocess_mode = \"thread\" #@param [\"None\", \"process\", \"thread\"]\n",
         "if multiprocess_mode == \"None\":\n",
-        "  multiprocess_mode = None\n",
+        "    multiprocess_mode = None\n",
         "\n",
         "#@markdown You can control the number of threads/processes using `workers`. Default (if you do not set `workers`) is to use one worker per CPU core.\n",
         "\n",
-        "workers = 2 #@param integer\n",
+        "workers = 4 #@param integer\n",
         "\n",
         "results = tryptag.analyse_list(worklist, analyse, multiprocess_mode=multiprocess_mode, workers=workers)\n",
         "\n",
         "# print the results\n",
         "prettyprint_results(results)"
-      ],
-      "metadata": {
-        "id": "6KRDNvV97kUq"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "authorship_tag": "ABX9TyP873zpmLa7ZFN+ho6AH70X",
+      "include_colab_link": true,
+      "private_outputs": true,
+      "provenance": []
+    },
+    "gpuClass": "standard",
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/examples/localisation_search.ipynb
+++ b/examples/localisation_search.ipynb
@@ -1,27 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "private_outputs": true,
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "gpuClass": "standard"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/zephyris/tryptag/blob/main/examples/localisation_search.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -44,6 +27,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "aHFBpe_qnCxD"
+      },
+      "outputs": [],
       "source": [
         "#@title Setup tryptag\n",
         "\n",
@@ -56,30 +44,20 @@
         "\n",
         "# define a function to print results nicely\n",
         "def prettyprint_hits(hits, max_shown=15):\n",
-        "  print(len(hits), \"hits\")\n",
-        "  for i in range(min(len(hits), max_shown)):\n",
-        "    print(hits[i].gene_id, hits[i].terminus, \":\", loc_to_str(tryptag.gene_list[hits[i].life_stage][hits[i].gene_id][hits[i].terminus][\"loc\"]))\n",
-        "  if len(hits) > max_shown:\n",
-        "    print(\" ... and\", len(hits) - max_shown, \"more\")\n",
-        "\n",
-        "# define a function to print localisation objects as nice strings\n",
-        "def loc_to_str(locs):\n",
-        "  loc_strs = []\n",
-        "  for loc in locs:\n",
-        "    str = loc[\"term\"]\n",
-        "    if \"modifiers\" in loc:\n",
-        "      str = str + \"[\"+\", \".join(loc[\"modifiers\"])+\"]\"\n",
-        "    loc_strs.append(str)\n",
-        "  return \", \".join(loc_strs)"
-      ],
-      "metadata": {
-        "id": "aHFBpe_qnCxD"
-      },
-      "execution_count": null,
-      "outputs": []
+        "    print(len(hits), \"hits\")\n",
+        "    for entry in hits[:max_shown]:\n",
+        "        print(f\"{entry.gene_id} {entry.terminus}: {entry.localisation}\")\n",
+        "    if len(hits) > max_shown:\n",
+        "        print(\" ... and\", len(hits) - max_shown, \"more\")"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "79iKcADInK8q"
+      },
+      "outputs": [],
       "source": [
         "#@title Simple search\n",
         "\n",
@@ -93,15 +71,24 @@
         "\n",
         "# result is a list of hits, in the form {\"gene_id\": gene_id, \"terminus\": terminus}\n",
         "prettyprint_hits(hits)"
-      ],
-      "metadata": {
-        "id": "79iKcADInK8q"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\"hello \".split(\",\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "OsbBurKSr0iT"
+      },
+      "outputs": [],
       "source": [
         "#@title Advanced search\n",
         "\n",
@@ -109,15 +96,15 @@
         "\n",
         "\n",
         "# term from the localisation ontology\n",
-        "query = \"nucleoplasm\" #@param {type:\"string\"}\n",
+        "query = \"spindle\" #@param {type:\"string\"}\n",
         "# true or false, whether to recurse matches to child structures\n",
-        "match_subterms = False #@param {type:\"boolean\"}\n",
+        "match_subterms = True #@param {type:\"boolean\"}\n",
         "\n",
         "#@markdown Comma delimited lists of modifiers\n",
         "# list of modifiers which preclude a hit\n",
         "exclude_modifiers = \"weak, <10%, 25%\" #@param {type:\"string\"}\n",
         "# list of modifiers which must be present for a hit\n",
-        "required_modifiers = \"strong\" #@param {type:\"string\"}\n",
+        "required_modifiers = \"cell cycle dependent\"#strong\" #@param {type:\"string\"}\n",
         "\n",
         "#@markdown If a localisation matching the query has _any_ modifier in the `exclude_modifiers` list then it will not be accepted as a hit.\n",
         "#@markdown A localisation matching the query must have _all_ of the modifiers in the `required_modifiers` list to be accepted as a hit.\n",
@@ -126,14 +113,11 @@
         "print(\"Match subterms:\", match_subterms)\n",
         "\n",
         "def split_to_list(str):\n",
-        "  # no entries, return None\n",
-        "  if str == \"\":\n",
-        "    return None\n",
-        "  # return split str\n",
-        "  if \",\" in str:\n",
+        "    # no entries, return None\n",
+        "    if str == \"\":\n",
+        "        return None\n",
+        "    # return split str\n",
         "    return [x.strip() for x in str.split(\",\")]\n",
-        "  # return one entry list containing str\n",
-        "  return [str.strip()]\n",
         "\n",
         "# parse excluded modifiers into a list\n",
         "exclude_modifiers = split_to_list(exclude_modifiers)\n",
@@ -144,15 +128,15 @@
         "\n",
         "hits = tryptag.localisation_search(query, match_subterms=match_subterms, exclude_modifiers=exclude_modifiers, required_modifiers=required_modifiers)\n",
         "prettyprint_hits(hits)"
-      ],
-      "metadata": {
-        "id": "OsbBurKSr0iT"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "vc0jOC9Fwhrb"
+      },
+      "outputs": [],
       "source": [
         "#@title Combining search results\n",
         "\n",
@@ -160,7 +144,7 @@
         "\n",
         "query_1 = \"nucleoplasm\" #@param {type:\"string\"}\n",
         "query_2 = \"cytoplasm\" #@param {type:\"string\"}\n",
-        "combine_strategy = \"intersection\" #@param [\"union\", \"intersection\", \"1 minus 2\"]\n",
+        "combine_strategy = \"union\" #@param [\"union\", \"intersection\", \"1 minus 2\"]\n",
         "\n",
         "# do the searches\n",
         "print(\"Query 1\")\n",
@@ -173,49 +157,27 @@
         "prettyprint_hits(hits_2, max_shown=5)\n",
         "print(\"\")\n",
         "\n",
-        "# define union, intersection and 1 minus 2 functions\n",
-        "def union(hits_1, hits_2):\n",
-        "  hits = hits_1.copy()\n",
-        "  for hit in hits_2:\n",
-        "    if hit not in hits:\n",
-        "      hits.append(hit)\n",
-        "  return hits\n",
-        "\n",
-        "def intersection(hits_1, hits_2):\n",
-        "  hits = []\n",
-        "  for hit in hits_1:\n",
-        "    if hit in hits_2:\n",
-        "      hits.append(hit)\n",
-        "  return hits\n",
-        "\n",
-        "def minus(hits_1, hits_2):\n",
-        "  hits = []\n",
-        "  for hit in hits_1:\n",
-        "    if hit not in hits_2:\n",
-        "      hits.append(hit)\n",
-        "  return hits\n",
-        "\n",
         "# print the combined hits\n",
         "if combine_strategy == \"union\":\n",
-        "  print(\"Union\")\n",
-        "  prettyprint_hits(union(hits_1, hits_2), max_shown=5)\n",
+        "    print(\"Union\")\n",
+        "    prettyprint_hits(hits_1.union(hits_2), max_shown=5)\n",
         "\n",
         "if combine_strategy == \"intersection\":\n",
-        "  print(\"Intersection\")\n",
-        "  prettyprint_hits(intersection(hits_1, hits_2), max_shown=5)\n",
+        "    print(\"Intersection\")\n",
+        "    prettyprint_hits(hits_2.intersection(hits_2), max_shown=5)\n",
         "\n",
-        "if combine_strategy == \"1minus2\":\n",
-        "  print(\"Query 1 minus query 2\")\n",
-        "  prettyprint_hits(minus(hits_1, hits_2), max_shown=5)"
-      ],
-      "metadata": {
-        "id": "vc0jOC9Fwhrb"
-      },
-      "execution_count": null,
-      "outputs": []
+        "if combine_strategy == \"1 minus 2\":\n",
+        "    print(\"Query 1 minus query 2\")\n",
+        "    prettyprint_hits(hits_1.difference(hits_2), max_shown=5)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "YHkvHQCC4LPS"
+      },
+      "outputs": [],
       "source": [
         "#@title Ontology\n",
         "\n",
@@ -227,29 +189,58 @@
         "#@markdown A special `root` term is used as the base of the ontology. All localisations are a subterm of `root`.\n",
         "\n",
         "def prettyprint_ontology(ontology):\n",
-        "  for entry in ontology:\n",
-        "    print(entry)\n",
-        "    print(\"-\" * len(entry))\n",
-        "    if \"synonyms\" in ontology[entry]: print(\"Synonyms:\", \", \".join(ontology[entry][\"synonyms\"]))\n",
-        "    if \"comment\" in ontology[entry]: print(\"Description:\", ontology[entry][\"comment\"])\n",
-        "    if \"ident\" in ontology[entry]: print(\"Identification:\", ontology[entry][\"ident\"])\n",
-        "    if \"go\" in ontology[entry]: print(\"GO term:\", \"http://amigo.geneontology.org/amigo/term/\"+ontology[entry][\"go\"])\n",
-        "    print(\"Parent hierachy:\", \" -> \".join(ontology[entry][\"parent\"]))\n",
-        "    if \"children\" in ontology[entry]: print(\"Children:\", \", \".join(ontology[entry][\"children\"]))\n",
-        "    if \"examples\" in ontology[entry]:\n",
-        "      urls = []\n",
-        "      for example in ontology[entry][\"examples\"]:\n",
-        "        urls.append(\"http://tryptag.org/?id=\"+example[\"id\"])\n",
-        "      print(\"Examples:\", \", \".join(urls))\n",
+        "    for entry in ontology:\n",
+        "        print(entry)\n",
+        "        print(\"-\" * len(entry))\n",
+        "        if \"synonyms\" in ontology[entry]: print(\"Synonyms:\", \", \".join(ontology[entry][\"synonyms\"]))\n",
+        "        if \"comment\" in ontology[entry]: print(\"Description:\", ontology[entry][\"comment\"])\n",
+        "        if \"ident\" in ontology[entry]: print(\"Identification:\", ontology[entry][\"ident\"])\n",
+        "        if \"go\" in ontology[entry]: print(\"GO term:\", \"http://amigo.geneontology.org/amigo/term/\"+ontology[entry][\"go\"])\n",
+        "        print(\"Parent hierachy:\", \" -> \".join(ontology[entry][\"parent\"]))\n",
+        "        if \"children\" in ontology[entry]: print(\"Children:\", \", \".join(ontology[entry][\"children\"]))\n",
+        "        if \"examples\" in ontology[entry]:\n",
+        "            urls = []\n",
+        "            for example in ontology[entry][\"examples\"]:\n",
+        "                urls.append(\"http://tryptag.org/?id=\"+example[\"id\"])\n",
+        "            print(\"Examples:\", \", \".join(urls))\n",
         "    print(\"\")\n",
         "\n",
         "prettyprint_ontology(tryptag.localisation_ontology)"
-      ],
-      "metadata": {
-        "id": "YHkvHQCC4LPS"
-      },
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": null,
-      "outputs": []
+      "metadata": {},
+      "outputs": [],
+      "source": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "include_colab_link": true,
+      "private_outputs": true,
+      "provenance": []
+    },
+    "gpuClass": "standard",
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/examples/open_cell.ipynb
+++ b/examples/open_cell.ipynb
@@ -100,7 +100,7 @@
         "#@markdown 4. `.dna_mask` Mask from thresholded DNA stain\n",
         "#@markdown 5. `.phase_mask_othercells` Mask from thresholded phase contrast for other cells\n",
         "\n",
-        "#@markdown The first time you open a cell it will take some time for `tryptag` to download the necessary data from [Zenodo](https://zenodo.org).\n",
+        "#@markdown The first time you open a cell it will take some time for `tryptag` to download the necessary data from the repository.\n",
         "#@markdown The data is saved in a cache directory, so the next time you open any cell for this cell line it will be far quicker.\n",
         "#@markdown Data is in 96 well plate groupings and download time will depend on how many images were captured for that plate - all this data will be cached.\n",
         "#@markdown In Google Colab this cache will (unfortunately) be deleted at the end of each session, but on your computer would be stored permanently.\n",

--- a/examples/open_cell.ipynb
+++ b/examples/open_cell.ipynb
@@ -1,28 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "private_outputs": true,
-      "authorship_tag": "ABX9TyNcmupKwTmtC+NoDUYjRuig",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "gpuClass": "standard"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/zephyris/tryptag/blob/main/examples/open_cell.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -45,18 +27,32 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gx5fO6l8BaU8"
+      },
+      "outputs": [],
       "source": [
         "#@title Setup tryptag\n",
         "\n",
         "#@markdown The `tryptag` module handles all data retrieval.\n",
         "\n",
         "# import and set up TryTag instance\n",
-        "from tryptag import TrypTag, CellLine\n",
+        "from tryptag import (\n",
+        "    TrypTag,\n",
+        "    CellLine,\n",
+        "    CellImage,\n",
+        "    GeneNotFoundError,\n",
+        "    InvalidTerminusError,\n",
+        "    FieldNotFoundError,\n",
+        "    CellNotFoundError,\n",
+        ")\n",
         "tryptag = TrypTag()\n",
         "\n",
         "# import skimage and numpy, for handling and displaying the images\n",
         "import skimage\n",
         "import numpy\n",
+        "from PIL import Image\n",
         "\n",
         "# filter matplotlib warnings, used by skimage for image display\n",
         "import warnings\n",
@@ -64,35 +60,28 @@
         "\n",
         "# function for quickly displaying some images\n",
         "def quickshow_images(image):\n",
-        "  # show individual channels\n",
-        "  print(\"phase\")\n",
-        "  skimage.io.imshow(image.phase)\n",
-        "  skimage.io.show()\n",
-        "  print(\"\")\n",
-        "  print(\"mng\")\n",
-        "  skimage.io.imshow(image.mng)\n",
-        "  skimage.io.show()\n",
-        "  print(\"\")\n",
-        "  print(\"dna\")\n",
-        "  skimage.io.imshow(image.dna)\n",
-        "  skimage.io.show()\n",
-        "  print(\"\")\n",
-        "  print(\"phase_mask\")\n",
-        "  skimage.io.imshow(image.phase_mask)\n",
-        "  skimage.io.show()\n",
-        "  print(\"\")\n",
-        "  print(\"dna_mask\")\n",
-        "  skimage.io.imshow(image.dna_mask)\n",
-        "  skimage.io.show()"
-      ],
-      "metadata": {
-        "id": "gx5fO6l8BaU8"
-      },
-      "execution_count": null,
-      "outputs": []
+        "    # show composite\n",
+        "    display(image)\n",
+        "    # show individual channels\n",
+        "    print(\"phase\")\n",
+        "    display(image.phase)\n",
+        "    print(\"mng\")\n",
+        "    display(image.mng)\n",
+        "    print(\"dna\")\n",
+        "    display(image.dna)\n",
+        "    print(\"phase_mask\")\n",
+        "    display(image.phase_mask)\n",
+        "    print(\"dna_mask\")\n",
+        "    display(image.dna_mask)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "AjfPO6YUuhLq"
+      },
+      "outputs": [],
       "source": [
         "#@title Open images for a cell\n",
         "\n",
@@ -124,15 +113,15 @@
         "\n",
         "# show the images\n",
         "quickshow_images(cell_image)"
-      ],
-      "metadata": {
-        "id": "AjfPO6YUuhLq"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "oFUkZSfNb8NK"
+      },
+      "outputs": [],
       "source": [
         "#@title Open cell image options\n",
         "\n",
@@ -143,8 +132,7 @@
         "positive_width = 120 #@param {type:\"integer\"}\n",
         "cell_image = tryptag.open_cell(cell_line, field_index, cell_index, width = positive_width)\n",
         "print(\"width\", positive_width)\n",
-        "skimage.io.imshow(cell_image.phase_mask)\n",
-        "skimage.io.show()\n",
+        "display(cell_image.phase_mask)\n",
         "print(\"\")\n",
         "\n",
         "#@markdown Set `rotate` to `True` to provide a nice rotated image (with half height) - good for figures, but not so good for image analysis!\n",
@@ -152,8 +140,7 @@
         "rotate = True #@param {type:\"boolean\"}\n",
         "cell_image = tryptag.open_cell(cell_line, field_index, cell_index, rotate = rotate)\n",
         "print(\"rotate\", rotate)\n",
-        "skimage.io.imshow(cell_image.phase_mask)\n",
-        "skimage.io.show()\n",
+        "display(cell_image.phase_mask)\n",
         "print(\"\")\n",
         "\n",
         "#@markdown Provide a negative `width` parameter to crop to the `phase_mask` of the cell, but with a border of `-width` pixels.\n",
@@ -161,20 +148,19 @@
         "negative_width = -32 #@param {type:\"integer\"}\n",
         "cell_image = tryptag.open_cell(cell_line, field_index, cell_index, width = negative_width)\n",
         "print(\"width\", negative_width)\n",
-        "skimage.io.imshow(cell_image.phase_mask)\n",
-        "skimage.io.show()\n",
+        "display(cell_image.phase_mask)\n",
         "\n",
         "#@markdown The images will always be of the requested width / have the requested border.\n",
         "#@markdown If necessary, the edge of the image will be extended with the median of the field of view."
-      ],
-      "metadata": {
-        "id": "oFUkZSfNb8NK"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "QJUinhCWAAnY"
+      },
+      "outputs": [],
       "source": [
         "#@title Image processing\n",
         "\n",
@@ -190,39 +176,35 @@
         "\n",
         "# mng\n",
         "print(\"mNG fluorescence\")\n",
-        "skimage.io.imshow(cell_image.mng)\n",
-        "skimage.io.show()\n",
+        "display(cell_image.mng)\n",
         "print(\"\")\n",
         "\n",
         "# mng, minus median\n",
         "print(\"... minus the image median and clipped to positive values\")\n",
         "mng_bgs = cell_image.mng - numpy.median(cell_image.mng)\n",
         "mng_bgs[mng_bgs < 0] = 0\n",
-        "skimage.io.imshow(mng_bgs)\n",
-        "skimage.io.show()\n",
+        "display(mng_bgs)\n",
         "print(\"\")\n",
         "\n",
         "# mng, with rolling ball filter\n",
         "print(\"... with rolling ball filter, radius 5 px\")\n",
         "mng_rb = skimage.restoration.rolling_ball(cell_image.mng, radius = 5)\n",
-        "skimage.io.imshow(cell_image.mng - mng_rb)\n",
-        "skimage.io.show()\n",
+        "display(cell_image.mng - mng_rb)\n",
         "print(\"\")\n",
         "\n",
         "# mng, with rolling ball filter\n",
         "print(\"... median subtracted and masked with phase contrast mask image\")\n",
         "mng_ma = (cell_image.mng - numpy.median(cell_image.mng)) * cell_image.phase_mask / 255\n",
-        "skimage.io.imshow(mng_ma)\n",
-        "skimage.io.show()"
-      ],
-      "metadata": {
-        "id": "QJUinhCWAAnY"
-      },
-      "execution_count": null,
-      "outputs": []
+        "display(mng_ma)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "-cNUncic4US8"
+      },
+      "outputs": [],
       "source": [
         "#@title Open field of view\n",
         "\n",
@@ -241,15 +223,15 @@
         "\n",
         "# show the images\n",
         "quickshow_images(field_image)"
-      ],
-      "metadata": {
-        "id": "-cNUncic4US8"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "zZxuHSytHs-o"
+      },
+      "outputs": [],
       "source": [
         "#@title Advanced usage\n",
         "\n",
@@ -283,23 +265,23 @@
         "# invert phase contrast image\n",
         "phase = None\n",
         "if invert_phase:\n",
-        "  phase = 2**16 - field_image.phase\n",
+        "    phase = int(2**16-1) - field_image.phase\n",
         "\n",
         "# rolling ball subtraction for mng\n",
         "mng = None\n",
         "if rolling_ball_mng:\n",
-        "  mng = field_image.mng - skimage.restoration.rolling_ball(field_image.mng, radius = 5)\n",
+        "    mng = field_image.mng - skimage.restoration.rolling_ball(field_image.mng, radius = 5)\n",
         "\n",
         "# median subtraction for dna\n",
         "dna = None\n",
         "if median_subtract_dna:\n",
-        "  dna = field_image.dna - numpy.median(field_image.dna)\n",
+        "    dna = field_image.dna - numpy.median(field_image.dna)\n",
         "\n",
         "# size filter dth\n",
         "dna_mask = None\n",
         "if size_filter_dna_mask:\n",
-        "  dna_labelled = skimage.measure.label(field_image.dna_mask)\n",
-        "  dna_mask = skimage.morphology.remove_small_objects(dna_labelled, min_size = 250)\n",
+        "    dna_labelled = skimage.measure.label(field_image.dna_mask)\n",
+        "    dna_mask = skimage.morphology.remove_small_objects(dna_labelled, min_size = 250)\n",
         "\n",
         "# make a new FieldImage object to pass to the open_cell_custom function\n",
         "new_field_image = FieldImage(\n",
@@ -313,21 +295,21 @@
         ")\n",
         "\n",
         "# open cell images, using modified field images\n",
-        "cell_images = tryptag.open_cell_custom(cell_line, field_index, cell_index, custom_field_image = new_field_image)\n",
+        "cell_images = tryptag.open_cell(cell_line, field_index, cell_index, custom_field_image = new_field_image)\n",
         "\n",
         "#@markdown More advanced analysis can alter or generate a new thresholded phase contrast image.\n",
         "#@markdown This, along with custom `fill_centre`, `crop_centre` and `angle` parameters for cell locations, can be passed to `open_cell_custom`.\n",
         "\n",
         "quickshow_images(cell_images)"
-      ],
-      "metadata": {
-        "id": "zZxuHSytHs-o"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ijPdh4cyPQ7r"
+      },
+      "outputs": [],
       "source": [
         "#@title Handling errors\n",
         "\n",
@@ -335,20 +317,25 @@
         "\n",
         "bad_gene_id = \"Tb927.12.8570\" #@param {type:\"string\"}\n",
         "bad_terminus = \"o\" #@param [\"n\", \"c\"]\n",
-        "bad_field_index = 15 #@param {type:\"integer\"}\n",
+        "bad_field_index = 15 #15 #@param {type:\"integer\"}\n",
         "bad_cell_index = 120 #@param {type:\"integer\"}\n",
-        "\n",
-        "# create a CellLine object to pass the data\n",
-        "bad_cell_line = CellLine(gene_id=bad_gene_id, terminus=bad_terminus)\n",
         "\n",
         "#@markdown Make sure you:\n",
         "#@markdown 1. either use the `try` `except` syntax,\n",
         "\n",
         "print(\"Try except method:\")\n",
         "try:\n",
-        "  cell_image = tryptag.open_cell(bad_cell_line, bad_field_index, bad_cell_index)\n",
-        "except:\n",
-        "  print(\"Oops, one of your query values does not exist!\")\n",
+        "    # create a CellLine object to pass the data\n",
+        "    bad_cell_line = CellLine(gene_id=bad_gene_id, terminus=bad_terminus)\n",
+        "    cell_image = tryptag.open_cell(bad_cell_line, bad_field_index, bad_cell_index)\n",
+        "except GeneNotFoundError as e:\n",
+        "    print(f\"Oops, your Gene ID {e.geneid} was not found!\")\n",
+        "except InvalidTerminusError as e:\n",
+        "    print(f\"Oops, the terminus {e.terminus} is invalid!\")\n",
+        "except FieldNotFoundError as e:\n",
+        "    print(f\"Oops, the field with index {e.index} could not be found!\")\n",
+        "except CellNotFoundError as e:\n",
+        "    print(f\"Oops, the cell with index {e.index} could not be found!\")\n",
         "print(\"\")\n",
         "\n",
         "#@markdown 2. or check that the necessary values in the `tryptag.gene_list` object exist.\n",
@@ -358,27 +345,53 @@
         "#@markdown This triggers data download then counting of fields of view and cells once the data is in the cache.\n",
         "\n",
         "print(\"Manual gene_list check method:\")\n",
-        "if bad_gene_id in tryptag.gene_list[\"procyclic\"]:\n",
-        "  if bad_terminus in tryptag.gene_list[\"procyclic\"][gene_id]:\n",
-        "    # fetch the data for this gene_id and terminus\n",
-        "    fieldcell_list = tryptag.cell_list(bad_cell_line)\n",
-        "    if bad_field_index < len(tryptag.gene_list[\"procyclic\"][bad_gene_id][bad_terminus][\"cells\"]):\n",
-        "      if bad_cell_index < len(tryptag.gene_list[\"procyclic\"][bad_gene_id][bad_terminus][\"cells\"][bad_field_index]):\n",
-        "        cell_image = tryptag.open_cell(bad_gene_id, bad_terminus, bad_field_index, bad_cell_index)\n",
-        "      else:\n",
-        "        print(\"cell_index\", bad_cell_index, \"out of range\")\n",
+        "if bad_gene_id in tryptag.gene_list:\n",
+        "    gene = tryptag.gene_list[bad_gene_id]\n",
+        "    if bad_terminus in tryptag.gene_list[bad_gene_id]:\n",
+        "        cell_line = gene[bad_terminus]\n",
+        "        # fetch the data for this gene_id and terminus\n",
+        "        if bad_field_index in cell_line.fields:\n",
+        "            field = cell_line.fields[bad_field_index]\n",
+        "            if bad_cell_index in field.cells:\n",
+        "                cell = field.cells[bad_cell_index]\n",
+        "                cell_image = CellImage(cell, rotated=False)\n",
+        "            else:\n",
+        "                print(\"cell_index\", bad_cell_index, \"out of range\")\n",
+        "        else:\n",
+        "            print(\"field_index\", bad_field_index, \"out of range\")\n",
         "    else:\n",
-        "      print(\"field_index\", bad_field_index, \"out of range\")\n",
-        "  else:\n",
-        "    print(\"data for terminus\", bad_terminus, \"not found\")\n",
+        "        print(\"data for terminus\", bad_terminus, \"not found\")\n",
         "else:\n",
         "  print(\"data for gene_id\", bad_gene_id, \"not found\")"
-      ],
-      "metadata": {
-        "id": "ijPdh4cyPQ7r"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "authorship_tag": "ABX9TyNcmupKwTmtC+NoDUYjRuig",
+      "include_colab_link": true,
+      "private_outputs": true,
+      "provenance": []
+    },
+    "gpuClass": "standard",
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/examples/tryptools.ipynb
+++ b/examples/tryptools.ipynb
@@ -1,28 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "private_outputs": true,
-      "provenance": [],
-      "authorship_tag": "ABX9TyOXZ8uchgPSyoZGODSaDgpQ",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "gpuClass": "standard"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/zephyris/tryptag/blob/main/examples/tryptools.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -40,11 +22,16 @@
         "\n",
         "#@markdown Install the `tryptag` module using `pip`.\n",
         "\n",
-        "!pip install git+https://github.com/zephyris/tryptag"
+        "!pip install git+https://github.com/zephyris/tryptag pandas"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "hzUBKod_3v1o"
+      },
+      "outputs": [],
       "source": [
         "#@title Setup tryptag\n",
         "\n",
@@ -53,15 +40,15 @@
         "# import and set up TryTag instance\n",
         "from tryptag import TrypTag, CellLine, tryptools\n",
         "tryptag = TrypTag()"
-      ],
-      "metadata": {
-        "id": "hzUBKod_3v1o"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "N6Joys7C34FP"
+      },
+      "outputs": [],
       "source": [
         "#@markdown Cells are opened using their `gene_id` (from [TriTrypDB](https://tritrypdb.org)) and tagged `terminus`, which must be `\"n\"` or `\"c\"`.\n",
         "gene_id = \"wild-type.1.0h\" #@param {type:\"string\"}\n",
@@ -74,15 +61,15 @@
         "\n",
         "#@markdown The opened cell image can be passed to various `tryptools` analysis methods.\n",
         "#@markdown All coordinates in the measurements are the position in this cell image, and will depend on the `width` used when opened."
-      ],
-      "metadata": {
-        "id": "N6Joys7C34FP"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "f5urJ_Ul5HLv"
+      },
+      "outputs": [],
       "source": [
         "#@title Signal analysis\n",
         "\n",
@@ -92,16 +79,16 @@
         "\n",
         "print(\"- signal analysis result -\")\n",
         "for key in result_signal:\n",
-        "  print(key+\":\", result_signal[key])"
-      ],
-      "metadata": {
-        "id": "f5urJ_Ul5HLv"
-      },
-      "execution_count": null,
-      "outputs": []
+        "    print(key+\":\", result_signal[key])"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "eIqp5cXK5OHH"
+      },
+      "outputs": [],
       "source": [
         "#@title KN analysis\n",
         "\n",
@@ -111,27 +98,27 @@
         "\n",
         "print(\"- kn analysis result -\")\n",
         "for key in result_kn:\n",
-        "  if key == \"objects_k\" or key == \"objects_n\":\n",
-        "    print(key+\":\")\n",
-        "    for index, value in enumerate(result_kn[key]):\n",
-        "      for key2 in value:\n",
-        "        if key2 == \"centroid\":\n",
-        "          print(\"\", key2+\":\", value[key2][\"x\"], \",\", value[key2][\"y\"])\n",
-        "        else:\n",
-        "          print(\"\", key2+\":\", value[key2])\n",
-        "  else:\n",
-        "    print(key+\":\", result_kn[key])\n",
+        "    if key == \"objects_k\" or key == \"objects_n\":\n",
+        "        print(key+\":\")\n",
+        "        for index, value in enumerate(result_kn[key]):\n",
+        "            for key2 in value:\n",
+        "                if key2 == \"centroid\":\n",
+        "                    print(\"\", key2+\":\", value[key2][\"x\"], \",\", value[key2][\"y\"])\n",
+        "                else:\n",
+        "                    print(\"\", key2+\":\", value[key2])\n",
+        "    else:\n",
+        "        print(key+\":\", result_kn[key])\n",
         "\n",
         "tryptools.plot_morphology_analysis(cell_image, result_kn)"
-      ],
-      "metadata": {
-        "id": "eIqp5cXK5OHH"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "vtD10qni5OdH"
+      },
+      "outputs": [],
       "source": [
         "#@title Midline analysis\n",
         "\n",
@@ -141,22 +128,22 @@
         "\n",
         "print(\"- midline analysis result -\")\n",
         "for key in result_midline:\n",
-        "  if key == \"midline\":\n",
-        "    print(key+\":\")\n",
-        "    print(\"\", \"[\", \"coordinates list of length\", len(result_midline), \"]\")\n",
-        "  else:\n",
-        "    print(key+\":\", result_midline[key])\n",
+        "    if key == \"midline\":\n",
+        "        print(key+\":\")\n",
+        "        print(\"\", \"[\", \"coordinates list of length\", len(result_midline), \"]\")\n",
+        "    else:\n",
+        "        print(key+\":\", result_midline[key])\n",
         "\n",
         "tryptools.plot_morphology_analysis(cell_image, result_midline)"
-      ],
-      "metadata": {
-        "id": "vtD10qni5OdH"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "nN8xqytp5O1v"
+      },
+      "outputs": [],
       "source": [
         "#@title Morphology analysis\n",
         "\n",
@@ -166,107 +153,109 @@
         "\n",
         "print(\"- morphology analysis result -\")\n",
         "for key in result_morphology:\n",
-        "  if key == \"objects_k\" or key == \"objects_n\":\n",
-        "    print(key+\":\")\n",
-        "    for index, value in enumerate(result_morphology[key]):\n",
-        "      for key2 in value:\n",
-        "        if key2 == \"centroid\":\n",
-        "          print(\"\", key2+\":\", value[key2][\"x\"], \",\", value[key2][\"y\"])\n",
-        "        else:\n",
-        "          print(\"\", key2+\":\", value[key2])\n",
-        "  elif key == \"midline\":\n",
-        "    print(key+\":\")\n",
-        "    print(\"\", \"[\", \"coordinates list of length\", len(result_morphology), \"]\")\n",
-        "  elif key == \"distance\":\n",
-        "    print(key+\":\")\n",
-        "    print(\"\", \"[\", \"midline distance list of length\", len(result_morphology), \"]\")\n",
-        "  else:\n",
-        "    print(key+\":\", result_morphology[key])\n",
+        "    if key == \"objects_k\" or key == \"objects_n\":\n",
+        "        print(key+\":\")\n",
+        "        for index, value in enumerate(result_morphology[key]):\n",
+        "            for key2 in value:\n",
+        "                if key2 == \"centroid\":\n",
+        "                    print(\"\", key2+\":\", value[key2][\"x\"], \",\", value[key2][\"y\"])\n",
+        "                else:\n",
+        "                    print(\"\", key2+\":\", value[key2])\n",
+        "    elif key == \"midline\":\n",
+        "        print(key+\":\")\n",
+        "        print(\"\", \"[\", \"coordinates list of length\", len(result_morphology), \"]\")\n",
+        "    elif key == \"distance\":\n",
+        "        print(key+\":\")\n",
+        "        print(\"\", \"[\", \"midline distance list of length\", len(result_morphology), \"]\")\n",
+        "    else:\n",
+        "        print(key+\":\", result_morphology[key])\n",
         "\n",
         "tryptools.plot_morphology_analysis(cell_image, result_morphology)\n",
         "\n",
         "if \"midline\" in result_morphology:\n",
-        "  print(\"\")\n",
-        "  print(\"- interpreted summary -\")\n",
-        "  print(\"cell length:\", result_morphology[\"distance\"][-1], \"px\")\n",
-        "  if \"objects_k\" in result_morphology:\n",
-        "    print(\"posterior - kinetoplast distance:\")\n",
-        "    for k in range(len(result_morphology[\"objects_k\"])):\n",
-        "      print(\"\", \"k\", k+1, result_morphology[\"distance\"][result_morphology[\"objects_k\"][k][\"midline_index\"]], \"px\")\n",
-        "  if \"objects_n\" in result_morphology:\n",
-        "    print(\"posterior - nucleus distance:\")\n",
-        "    for n in range(len(result_morphology[\"objects_n\"])):\n",
-        "      print(\"\", \"n\", n+1, result_morphology[\"distance\"][result_morphology[\"objects_n\"][n][\"midline_index\"]], \"px\")\n",
+        "    print(\"\")\n",
+        "    print(\"- interpreted summary -\")\n",
+        "    print(\"cell length:\", result_morphology[\"distance\"][-1], \"px\")\n",
+        "    if \"objects_k\" in result_morphology:\n",
+        "        print(\"posterior - kinetoplast distance:\")\n",
+        "        for k in range(len(result_morphology[\"objects_k\"])):\n",
+        "            print(\"\", \"k\", k+1, result_morphology[\"distance\"][result_morphology[\"objects_k\"][k][\"midline_index\"]], \"px\")\n",
+        "    if \"objects_n\" in result_morphology:\n",
+        "        print(\"posterior - nucleus distance:\")\n",
+        "        for n in range(len(result_morphology[\"objects_n\"])):\n",
+        "            print(\"\", \"n\", n+1, result_morphology[\"distance\"][result_morphology[\"objects_n\"][n][\"midline_index\"]], \"px\")\n",
         "else:\n",
-        "  print(\"- midline not available because: -\")\n",
-        "  if result_morphology[\"termini\"] != 2:\n",
-        "    print(\"termini\", result_morphology[\"termini\"])\n",
-        "  if result_morphology[\"branches\"] != 0:\n",
-        "    print(\"branches\", result_morphology[\"branches\"])"
-      ],
-      "metadata": {
-        "id": "nN8xqytp5O1v"
-      },
-      "execution_count": null,
-      "outputs": []
+        "    print(\"- midline not available because: -\")\n",
+        "    if result_morphology[\"termini\"] != 2:\n",
+        "        print(\"termini\", result_morphology[\"termini\"])\n",
+        "    if result_morphology[\"branches\"] != 0:\n",
+        "        print(\"branches\", result_morphology[\"branches\"])"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "mOUYgmZR9TIB"
+      },
+      "outputs": [],
       "source": [
         "#@title Example application\n",
         "\n",
         "#@markdown Flow cytometry-like cell cycle analysis of a cell line.\n",
         "\n",
-        "def cell_cycle_analysis(cell_line):\n",
-        "  results = {\"kn\": [], \"kdna\": [], \"karea\": [], \"ndna\": [], \"narea\": [], \"length\": [], \"area\": []}\n",
-        "  print(cell_line)\n",
-        "  fieldcell_list = tryptag.cell_list(cell_line)\n",
-        "  for cell in fieldcell_list:\n",
-        "    cell_image = tryptag.open_cell(cell_line, cell[\"field_index\"], cell[\"cell_index\"], width=-32)\n",
-        "    morphometry_analysis = tryptools.cell_morphology_analysis(cell_image)\n",
-        "    signal_analysis = tryptools.cell_signal_analysis(cell_image)\n",
-        "    if \"distance\" in morphometry_analysis:\n",
-        "      # area result\n",
-        "      results[\"area\"].append(signal_analysis[\"cell_area\"])\n",
-        "      # kn result\n",
-        "      kn = morphometry_analysis[\"count_kn\"]\n",
-        "      if morphometry_analysis[\"count_kn\"] not in [\"1K1N\", \"2K1N\", \"2K2N\"]:\n",
-        "        kn = \"other\"\n",
-        "      results[\"kn\"].append(kn)\n",
-        "      # kdna and karea result\n",
-        "      kdna = 0\n",
-        "      karea = 0\n",
-        "      if \"objects_k\" in morphometry_analysis:\n",
-        "        for k in morphometry_analysis[\"objects_k\"]:\n",
-        "          kdna += k[\"dna_sum\"]\n",
-        "          karea += k[\"area\"]\n",
-        "      results[\"kdna\"].append(kdna)\n",
-        "      results[\"karea\"].append(karea)\n",
-        "      # ndna and narea result\n",
-        "      ndna = 0\n",
-        "      narea = 0\n",
-        "      if \"objects_n\" in morphometry_analysis:\n",
-        "        for n in morphometry_analysis[\"objects_n\"]:\n",
-        "          ndna += n[\"dna_sum\"]\n",
-        "          narea += n[\"area\"]\n",
-        "      results[\"ndna\"].append(ndna)\n",
-        "      results[\"narea\"].append(narea)\n",
-        "      # length result\n",
-        "      results[\"length\"].append(morphometry_analysis[\"distance\"][-1])\n",
-        "  return results\n",
+        "from tryptag.images import CellImage\n",
         "\n",
-        "print(gene_id, terminus)\n",
-        "tryptag.gene_list[\"procyclic\"][\"Tb927.9.8570\"][\"n\"][\"plate\"]\n",
-        "cell_cycle = cell_cycle_analysis(CellLine(gene_id, terminus, \"procyclic\"))"
-      ],
-      "metadata": {
-        "id": "mOUYgmZR9TIB"
-      },
-      "execution_count": null,
-      "outputs": []
+        "\n",
+        "def cell_cycle_analysis(cell_line):\n",
+        "    results = {\"kn\": [], \"kdna\": [], \"karea\": [], \"ndna\": [], \"narea\": [], \"length\": [], \"area\": []}\n",
+        "    print(cell_line)\n",
+        "    fieldcell_list = tryptag.cell_list(cell_line)\n",
+        "    for cell in fieldcell_list:\n",
+        "        cell_image = CellImage(cell, rotated=False, width=-32)\n",
+        "        morphometry_analysis = tryptools.cell_morphology_analysis(cell_image)\n",
+        "        signal_analysis = tryptools.cell_signal_analysis(cell_image)\n",
+        "        if \"distance\" in morphometry_analysis:\n",
+        "            # area result\n",
+        "            results[\"area\"].append(signal_analysis[\"cell_area\"])\n",
+        "            # kn result\n",
+        "            kn = morphometry_analysis[\"count_kn\"]\n",
+        "            if morphometry_analysis[\"count_kn\"] not in [\"1K1N\", \"2K1N\", \"2K2N\"]:\n",
+        "                kn = \"other\"\n",
+        "            results[\"kn\"].append(kn)\n",
+        "            # kdna and karea result\n",
+        "            kdna = 0\n",
+        "            karea = 0\n",
+        "            if \"objects_k\" in morphometry_analysis:\n",
+        "                for k in morphometry_analysis[\"objects_k\"]:\n",
+        "                    kdna += k[\"dna_sum\"]\n",
+        "                    karea += k[\"area\"]\n",
+        "            results[\"kdna\"].append(kdna)\n",
+        "            results[\"karea\"].append(karea)\n",
+        "            # ndna and narea result\n",
+        "            ndna = 0\n",
+        "            narea = 0\n",
+        "            if \"objects_n\" in morphometry_analysis:\n",
+        "                for n in morphometry_analysis[\"objects_n\"]:\n",
+        "                    ndna += n[\"dna_sum\"]\n",
+        "                    narea += n[\"area\"]\n",
+        "            results[\"ndna\"].append(ndna)\n",
+        "            results[\"narea\"].append(narea)\n",
+        "            # length result\n",
+        "            results[\"length\"].append(morphometry_analysis[\"distance\"][-1])\n",
+        "    return results\n",
+        "\n",
+        "cell_line = tryptag.gene_list[gene_id][terminus]\n",
+        "cell_cycle = cell_cycle_analysis(cell_line)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ko6vf1wiDpyq"
+      },
+      "outputs": [],
       "source": [
         "#@title Example plotting\n",
         "\n",
@@ -280,17 +269,40 @@
         "\n",
         "groups = df.groupby('kn')\n",
         "for name, group in groups:\n",
-        "  plt.scatter(x=group['length'],y=group['ndna'],label=name)\n",
+        "    plt.scatter(x=group['length'],y=group['ndna'],label=name)\n",
         "plt.legend()\n",
         "plt.xlabel(\"length\")\n",
         "plt.ylabel(\"ndna\")\n",
         "plt.show()"
-      ],
-      "metadata": {
-        "id": "ko6vf1wiDpyq"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "authorship_tag": "ABX9TyOXZ8uchgPSyoZGODSaDgpQ",
+      "include_colab_link": true,
+      "private_outputs": true,
+      "provenance": []
+    },
+    "gpuClass": "standard",
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires-python = ">=3.8"
 dependencies = [
 	"numpy",
 	"scikit-image",
+	"Pillow",
 	"tqdm",
 	"types-tqdm",
 	"filelock",

--- a/src/tryptag/__init__.py
+++ b/src/tryptag/__init__.py
@@ -1,6 +1,22 @@
 import logging
 import sys
 from .tryptag import TrypTag, FieldImage, CellImage, CellLine
-__all__ = ["TrypTag", "FieldImage", "CellImage", "CellLine"]
+from .datasource import (
+    GeneNotFoundError,
+    InvalidTerminusError,
+    FieldNotFoundError,
+    CellNotFoundError,
+)
+
+__all__ = [
+    "TrypTag",
+    "FieldImage",
+    "CellImage",
+    "CellLine",
+    "GeneNotFoundError",
+    "InvalidTerminusError",
+    "FieldNotFoundError",
+    "CellNotFoundError",
+]
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)

--- a/src/tryptag/datasource.py
+++ b/src/tryptag/datasource.py
@@ -26,6 +26,30 @@ else:
 logger = logging.getLogger("tryptag.datasource")
 
 
+class GeneNotFoundError(KeyError):
+    def __init__(self, geneid: str):
+        super().__init__(self, f"Gene ID {geneid} not found.")
+        self.geneid = geneid
+
+
+class InvalidTerminusError(KeyError):
+    def __init__(self, terminus: str):
+        super().__init__(self, f"Invalid terminus {terminus} specified.")
+        self.terminus = terminus
+
+
+class FieldNotFoundError(KeyError):
+    def __init__(self, index):
+        super().__init__(f"No field with index {index} found.")
+        self.index = index
+
+
+class CellNotFoundError(KeyError):
+    def __init__(self, index):
+        super().__init__(f"No cell with index {index} found.")
+        self.index = index
+
+
 class HeadersGene(StrEnum):
     """Column headers that document gene properties in localisations.tsv"""
 
@@ -127,16 +151,6 @@ class Cell:
         return f"Cell from {self.field}"
 
 
-class FieldDoesNotExistError(Exception):
-    def __init__(
-        self,
-        cell_line: CellLine,
-        index: int,
-    ):
-        self.cell_line = cell_line
-        self.index = index
-
-
 class Field:
     """Class describing metadata for a `CellLine`'s field of view."""
     def __init__(
@@ -158,7 +172,7 @@ class Field:
         self.datasource = datasource
 
         if not self.exists():
-            raise FieldDoesNotExistError(self.cell_line, self.index)
+            raise FieldNotFoundError(self.index)
 
         cell_file = datasource.load_plate_file(
             cell_line.plate,
@@ -168,7 +182,7 @@ class Field:
             # Skip header line
             next(cell_file)
             cell_list = [Cell.from_line(self, line) for line in cell_file]
-            self.cells = {cell.index: cell for cell in cell_list}
+        self.cells = CellCollection(cell_list)
 
     def filename(self, file_type: FileTypes):
         """Return the name of the given file type for this field of view."""
@@ -194,6 +208,54 @@ class Field:
         return f"{self.cell_line} index = {self.index}"
 
 
+class FieldCollection(Mapping):
+    """Class holding a collection of Fields."""
+    def __init__(self, fields: list[Field]):
+        """Initialise a field collection.
+
+        :param fields: list of Fields
+        """
+        self._fields = {
+            field.index: field for field in fields
+        }
+
+    def __getitem__(self, index: int):
+        try:
+            return self._fields[index]
+        except KeyError:
+            raise FieldNotFoundError(index)
+
+    def __len__(self):
+        return len(self._fields)
+
+    def __iter__(self):
+        return iter(self._fields)
+
+
+class CellCollection(Mapping):
+    """Class holding a collection of Cells."""
+    def __init__(self, cells: list[Cell]):
+        """Initialise a cell collection.
+
+        :param fields: list of Cell
+        """
+        self._cells = {
+            cell.index: cell for cell in cells
+        }
+
+    def __getitem__(self, index: int):
+        try:
+            return self._cells[index]
+        except KeyError:
+            raise CellNotFoundError(index)
+
+    def __len__(self):
+        return len(self._cells)
+
+    def __iter__(self):
+        return iter(self._cells)
+
+
 class CellLine:
     """Class describing a cell line within the TrypTag project."""
     gene: Gene = None
@@ -213,7 +275,8 @@ class CellLine:
     def __init__(
         self,
         gene_id: str,
-        terminus: str
+        terminus: str,
+        life_stage: str | None = None,
     ):
         """
         Create a `CellLine` object.
@@ -225,11 +288,14 @@ class CellLine:
         :param terminus: str, terminus of the tag on the cell line (either "C"
             or "N")
         """
+        if life_stage is not None:
+            warnings.warn("life_stage is deprecated and ignored.")
+
         self._initialised = False
         self._gene_id = gene_id
         terminus = terminus.upper()
         if terminus not in ["N", "C"]:
-            raise ValueError("terminus needs to be either 'N' or 'C'")
+            raise InvalidTerminusError(terminus)
         self.terminus = terminus
 
     @property
@@ -309,7 +375,7 @@ class CellLine:
     def __hash__(self):
         return hash(
             (self.datasource, self.gene.id, self.terminus, self.life_stage))
-    
+
     def __eq__(self, other: CellLine):
         return (
             self.gene_id == other.gene_id and
@@ -327,23 +393,25 @@ class CellLine:
         return f"{self.gene.id}_4_{self.terminus}_"
 
     @cached_property
-    def fields(self) -> dict[int, Field]:
+    def fields(self) -> FieldCollection:
         """The `Field`s of view belonging to this cell line."""
         if self.status != CellLineStatus.GENERATED:
-            return {}
-        stem = self.filename_stem()
-        files = self.datasource.glob_plate_files(
-            self.plate,
-            f"{stem}*{FILE_PATTERN}",
-        )
-        indices = [
-            int(fname.replace(stem, "").replace(FILE_PATTERN, "")) - 1
-            for fname in files
-        ]
-        return {
-            index: Field(self, index, self.datasource)
-            for index in sorted(indices)
-        }
+            fields = []
+        else:
+            stem = self.filename_stem()
+            files = self.datasource.glob_plate_files(
+                self.plate,
+                f"{stem}*{FILE_PATTERN}",
+            )
+            indices = [
+                int(fname.replace(stem, "").replace(FILE_PATTERN, "")) - 1
+                for fname in files
+            ]
+            fields = [
+                Field(self, index, self.datasource)
+                for index in sorted(indices)
+            ]
+        return FieldCollection(fields)
 
     def __getitem__(self, key):
         warnings.warn(
@@ -384,7 +452,7 @@ class Gene(Mapping):
         elif terminus == "C":
             return self.C
         else:
-            raise KeyError(f"Terminus {terminus} unknown.")
+            raise InvalidTerminusError(terminus)
 
     def __iter__(self):
         return iter(["C", "N"])
@@ -409,7 +477,10 @@ class GeneCollection(Mapping):
                 "Specifying a life stage is deprecated."
             )
             return self
-        return self.genes[geneid]
+        try:
+            return self.genes[geneid]
+        except KeyError:
+            raise GeneNotFoundError(geneid)
 
     def __iter__(self):
         return iter(self.genes)

--- a/src/tryptag/processing.py
+++ b/src/tryptag/processing.py
@@ -46,6 +46,24 @@ class WorkList(Sequence[CellLine]):
     def __repr__(self):
         return f"WorkList([{','.join([str(c) for c in self])}])"
 
+    def union(self, other: WorkList):
+        return WorkList(
+            self.tryptag,
+            set(self).union(set(other))
+        )
+
+    def intersection(self, other: WorkList):
+        return WorkList(
+            self.tryptag,
+            set(self).intersection(set(other))
+        )
+
+    def difference(self, other: WorkList):
+        return WorkList(
+            self.tryptag,
+            set(self).difference(set(other))
+        )
+
     def filter(
         self,
         filter_function: Callable[[CellLine], bool]

--- a/src/tryptag/tryptools/tryptools.py
+++ b/src/tryptag/tryptools/tryptools.py
@@ -18,7 +18,7 @@ def cell_signal_analysis(cell_image) -> dict:
     lab = skimage.measure.label(cell_image.phase_mask)
     props_table = skimage.measure.regionprops_table(
         lab,
-        mng,
+        numpy.array(mng),  # skimage doesn't like subclassed numpy arrays
         properties=("area", "intensity_max", "intensity_mean", "intensity_min")
     )
     return {
@@ -113,12 +113,12 @@ def cell_kn_analysis(cell_image, min_area=17, kn_threshold_area=250):
     dna_lab = skimage.measure.label(cell_image.dna_mask)
     pth_props_table = skimage.measure.regionprops_table(
         dna_lab,
-        cell_image.phase_mask,
+        numpy.array(cell_image.phase_mask),  # skimage doesn't like subclassed numpy arrays
         properties=("intensity_max", "area_convex")
     )
     dna_props_table = skimage.measure.regionprops_table(
         dna_lab,
-        dna,
+        numpy.array(dna),  # skimage doesn't like subclassed numpy arrays
         properties=(
             "intensity_mean",
             "intensity_max",


### PR DESCRIPTION
This PR updates the example notebooks with the changes from the data source abstraction.

It also implements rich display options for `CellImage` and `FieldImage`. This means putting `display(cell_image)` or `display(field_image)` into a notebook cell will automatically render a (crudely) autocontrasted, composite view of the cell or field.

Similarly, `display(cell_image.mng)` or `display(field_image.phase)` will show an autocontrasted version of the corresponding channels.

Finally, we now also have the set operations `union`, `intersection` and `difference` implemented directly implemented for `WorkList`.