### PR TITLE
Fix BIA fetch failure because of changed URL

### DIFF
--- a/src/tryptag/bia.py
+++ b/src/tryptag/bia.py
@@ -14,7 +14,7 @@ from tryptag.datasource import DataSource
 
 logger = logging.getLogger("tryptag.bia")
 
-BIA_API_ROOT = "https://ftp.ebi.ac.uk/pub/databases/biostudies/S-BIAD"
+BIA_API_ROOT = "https://ftp.ebi.ac.uk/biostudies/fire/S-BIAD/"
 DOWNLOAD_MAX_TRIES = 3
 
 FILE_TYPES = {


### PR DESCRIPTION
Old URL for file list was:
https://ftp.ebi.ac.uk/pub/databases/biostudies/S-BIAD1/866/S-BIAD1866/Files/Files.json

New URL for file list is:
https://ftp.ebi.ac.uk/biostudies/fire/S-BIAD/866/S-BIAD1866/Files/Files.json

Update BIA URL root accordingly.